### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,8 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
-          - 3.0
+          - '3.0'
+          - 3.1
           - jruby
           - truffleruby-head
     name: Ruby ${{ matrix.ruby }}

--- a/spec/advisory_spec.rb
+++ b/spec/advisory_spec.rb
@@ -45,7 +45,16 @@ describe Bundler::Audit::Advisory do
   end
 
   describe "load" do
-    let(:data) { YAML.load_file(path) }
+    let(:data) do
+      File.open( path ) do |yaml|
+        if Psych::VERSION >= '3.1.0'
+          YAML.safe_load(yaml, permitted_classes: [Date])
+        else
+          # XXX: psych < 3.1.0 YAML.safe_load calling convention
+          YAML.safe_load(yaml, [Date])
+        end
+      end
+    end
 
     describe '#id' do
       subject { super().id }

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -292,7 +292,7 @@ describe Bundler::Audit::Database do
       let(:last_commit) { Fixtures::Database::COMMIT }
       let(:last_commit_timestamp) do
         Dir.chdir(Fixtures::Database::PATH) do
-          Time.parse(`git log --date=iso8601 --pretty="%cd" #{last_commit}`)
+          Time.parse(`git log -n 2 --date=iso8601 --pretty="%cd" #{last_commit}`)
         end
       end
 


### PR DESCRIPTION
In addition to the CI configuration change this PR makes the following changes:

* Fixes YAML load in specs to permit Date
* Limits number of commit logs passed to Time.parse in spec so the string is less than 128 characters